### PR TITLE
Fix release workflow to trigger for all tags

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,7 +34,7 @@ jobs:
   release:
     needs: build
     runs-on: ubuntu-latest
-    if: startsWith(github.ref, 'refs/tags/v')
+    if: startsWith(github.ref, 'refs/tags/')
     
     steps:
     - name: Checkout


### PR DESCRIPTION
Fixes the release job being skipped for numeric tags like 0.1.0.

## Problem:
The release job had condition: `if: startsWith(github.ref, 'refs/tags/v')`
This only matches tags like `v1.0.0`, not `0.1.0`

## Solution:
Changed to: `if: startsWith(github.ref, 'refs/tags/')`
Now matches all tags.

## Testing:
After merging, delete and recreate tag 0.1.0 to trigger release.