### PR TITLE
Fix function call deduplication bug

### DIFF
--- a/src/gemini-api-client.ts
+++ b/src/gemini-api-client.ts
@@ -395,12 +395,16 @@ export class DirectGeminiAPIClient {
 			if (combinedText) {
 				combinedParts.push({ text: combinedText });
 			}
-			// Add function calls (remove duplicates by name)
-			const seenFunctionNames = new Set<string>();
+			// Add function calls (remove duplicates by name AND arguments)
+			// Use a unique key based on both function name and arguments to prevent
+			// discarding legitimate calls with same name but different arguments
+			const seenFunctionCalls = new Set<string>();
 			for (const funcCall of functionCalls) {
-				if (!seenFunctionNames.has(funcCall.name)) {
+				// Create unique key from function name and stringified arguments
+				const callKey = `${funcCall.name}:${JSON.stringify(funcCall.args || {})}`;
+				if (!seenFunctionCalls.has(callKey)) {
 					combinedParts.push({ functionCall: funcCall });
-					seenFunctionNames.add(funcCall.name);
+					seenFunctionCalls.add(callKey);
 				}
 			}
 			
@@ -744,12 +748,16 @@ export class DirectGeminiAPIClient {
 						if (combinedText) {
 							combinedParts.push({ text: combinedText });
 						}
-						// Add function calls (remove duplicates by name)
-						const seenFunctionNames = new Set<string>();
+						// Add function calls (remove duplicates by name AND arguments)
+						// Use a unique key based on both function name and arguments to prevent
+						// discarding legitimate calls with same name but different arguments
+						const seenFunctionCalls = new Set<string>();
 						for (const funcCall of functionCalls) {
-							if (!seenFunctionNames.has(funcCall.name)) {
+							// Create unique key from function name and stringified arguments
+							const callKey = `${funcCall.name}:${JSON.stringify(funcCall.args || {})}`;
+							if (!seenFunctionCalls.has(callKey)) {
 								combinedParts.push({ functionCall: funcCall });
-								seenFunctionNames.add(funcCall.name);
+								seenFunctionCalls.add(callKey);
 							}
 						}
 						finalResponse.candidates[0].content.parts = combinedParts;


### PR DESCRIPTION
Fixes the function call deduplication bug reported by Bugbot in PR #15.

**Issue:**
The deduplication logic was only checking function names, which caused legitimate calls with the same name but different arguments to be discarded. For example, multiple `read_file` calls with different file paths would be incorrectly deduplicated.

**Fix:**
- Changed deduplication to use both function name AND arguments
- Creates unique key: `${funcCall.name}:${JSON.stringify(funcCall.args || {})}`
- Still deduplicates truly identical calls (same name AND same arguments)
- Applied fix to both occurrences in `parseSSEChunk` and `parseTextChunk` functions

**Testing:**
- Build successful
- All existing tests pass
- Fixes the high severity bug identified by Bugbot

Addresses Bugbot issue: 'Deduplication by Name Causes Legitimate Call Losses'

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Update function call dedup to use name+arguments when assembling `content.parts` in SSE and array JSON responses.
> 
> - **`src/gemini-api-client.ts`**:
>   - **SSE parsing (`generateContent`)**: Replace name-only dedup with key `${funcCall.name}:${JSON.stringify(funcCall.args || {})}` when building `combinedParts`.
>   - **Array JSON parsing (`generateContentWithGrounding`)**: Apply the same name+args dedup logic when aggregating function calls into `combinedParts`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 50957f189c286bf38ebf23e54a03d6ff7ea8e8a6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->